### PR TITLE
Add : CAT-17 followe api 브랜치 모듈화로 리팩토링

### DIFF
--- a/catchup-api/src/docs/asciidoc/index.adoc
+++ b/catchup-api/src/docs/asciidoc/index.adoc
@@ -80,6 +80,45 @@ Catch-Up;
 
 operation::create-post[snippets='http-request,request-fields']
 
+[[find-all-post]]
+=== 모든 포스팅 조회
+
+operation::find-all-post[snippets='http-request,http-response']
+
+[[find-post]]
+=== 포스트 상세 조회
+
+operation::find-post[snippets='http-request,path-parameters,http-response']
+
+[[update-post]]
+=== 포스트 업데이트
+
+operation::update-post[snippets='http-request,path-parameters,request-fields,http-response']
+
+[[delete-post]]
+=== 특정 포스트 삭제
+
+operation::delete-post[snippets='http-request,path-parameters']
+
+[[find-post-likes]]
+=== 특정 게시글을 좋아요한 PostLike(사용자) 모두 찾기
+
+operation::find-post-likes[snippets='http-request,path-parameters,http-response']
+
+[[toggle-follow]]
+=== 팔로우 추가 or 삭제
+
+operation::toggle-follow[snippets='http-request,path-parameters,http-response']
+
+[[find-following]]
+=== 특정 ID가 팔로잉하는 사용자 리스트 불러오기
+
+operation::find-following[snippets='http-request,path-parameters,http-response']
+
+[[find-follower]]
+=== 특정 ID의 팔로워 리스트 불러오기
+
+operation::find-follower[snippets='http-request,path-parameters,http-response']
 
 [[create-postComment]]
 === 포스트 댓글 생성
@@ -90,12 +129,12 @@ operation::create-postComment[snippets='http-request,request-fields']
 [[get-postComments]]
 === 포스트 댓글 가져오기
 
-operation::get-postComments[snippets='http-request,path-parameters']
+operation::get-postComments[snippets='http-request,path-parameters,http-response']
 
 [[get-postCommentReplies]]
 === 포스트 대댓글 가져오기
 
-operation::get-postCommentReplies[snippets='http-request,path-parameters']
+operation::get-postCommentReplies[snippets='http-request,path-parameters,http-response']
 
 [[delete-postComment]]
 === 포스트 댓글 삭제
@@ -110,4 +149,5 @@ operation::auth[snippets='http-request']
 [[get-profile]]
 === 프로필 정보 가져오기
 
-operation::get-profile[snippets='http-request,path-parameters']
+operation::get-profile[snippets='http-request,path-parameters,http-response']
+

--- a/catchup-api/src/main/java/com/einschpanner/catchup/follow/api/FollowController.java
+++ b/catchup-api/src/main/java/com/einschpanner/catchup/follow/api/FollowController.java
@@ -1,4 +1,64 @@
 package com.einschpanner.catchup.follow.api;
 
+import com.einschpanner.catchup.domain.follow.domain.Follow;
+import com.einschpanner.catchup.domain.follow.dto.FollowDto;
+import com.einschpanner.catchup.follow.service.FollowService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequiredArgsConstructor
 public class FollowController {
+
+    private final FollowService followService;
+
+    @GetMapping("following")
+    @ResponseStatus(HttpStatus.OK)
+    public List<FollowDto.BlogRes> findMyFollowingBlog(){
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Long userId = (Long) authentication.getPrincipal();
+
+        List<Follow> follows = followService.findAllFollowing(userId);
+        return follows.stream()
+                .map(FollowDto.BlogRes::new)
+                .collect(Collectors.toList());
+    }
+
+    @PostMapping("following/{subscribeId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void toggleFollow(
+            @PathVariable final Long subscribeId
+    ){
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Long userId = (Long) authentication.getPrincipal();
+        followService.toggle(userId, subscribeId);
+    }
+
+    @GetMapping("following/{subscribeId}")
+    @ResponseStatus(HttpStatus.OK)
+    public List<FollowDto.FollowingRes> findFollowing(
+            @PathVariable final Long subscribeId
+    ){
+        List<Follow> followings = followService.findAllFollowing(subscribeId);
+        return followings.stream()
+                .map(FollowDto.FollowingRes::new)
+                .collect(Collectors.toList());
+    }
+
+    @GetMapping("follower/{subscribedId}")
+    @ResponseStatus(HttpStatus.OK)
+    public List<FollowDto.FollowerRes> findFollower(
+            @PathVariable final Long subscribedId
+    ){
+        List<Follow> followers = followService.findAllFollower(subscribedId);
+        return followers.stream()
+                .map(FollowDto.FollowerRes::new)
+                .collect(Collectors.toList());
+    }
 }

--- a/catchup-api/src/main/java/com/einschpanner/catchup/follow/service/FollowService.java
+++ b/catchup-api/src/main/java/com/einschpanner/catchup/follow/service/FollowService.java
@@ -1,0 +1,68 @@
+package com.einschpanner.catchup.follow.service;
+
+import com.einschpanner.catchup.domain.follow.dao.FollowQueryRepository;
+import com.einschpanner.catchup.domain.follow.dao.FollowRepository;
+import com.einschpanner.catchup.domain.follow.domain.Follow;
+import com.einschpanner.catchup.domain.user.dao.UserRepository;
+import com.einschpanner.catchup.domain.user.domain.User;
+import com.einschpanner.catchup.user.exception.UserNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.ObjectUtils;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FollowService {
+
+    private final UserRepository userRepository;
+    private final FollowRepository followRepository;
+    private final FollowQueryRepository followQueryRepository;
+
+    /**
+     * 토글 following, follower ( 팔로우 추가, 삭제 )
+     */
+    @Transactional
+    public void toggle(Long followerId, Long followingId) {
+
+        User follower = userRepository.findById(followerId)
+                .orElseThrow(UserNotFoundException::new);
+        User following = userRepository.findById(followingId)
+                .orElseThrow(UserNotFoundException::new);
+
+        Follow follow = followQueryRepository.exists(followerId, followingId);
+        if (ObjectUtils.isEmpty(follow)){
+            follower.plusFollowingCount();
+            following.plusFollowerCount();
+            followRepository.save(Follow.of(follower, following));
+        } else {
+            follower.minusFollowingCount();
+            following.minusFollowerCount();
+            followRepository.deleteById(follow.getFollowId());
+        }
+    }
+
+    /**
+     * 특정 ID가 팔로잉하는 사용자 리스트 불러오기
+     */
+    @Transactional
+    public List<Follow> findAllFollowing(Long userId) {
+        userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+
+        return followQueryRepository.findAllFollowingByFollowerId(userId);
+    }
+
+    /**
+     * 특정 ID의 팔로워 리스트 불러오기
+     */
+    @Transactional
+    public List<Follow> findAllFollower(Long userId) {
+        userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+
+        return followQueryRepository.findAllFollowerByFollowingId(userId);
+    }
+}

--- a/catchup-api/src/main/java/com/einschpanner/catchup/global/error/ErrorCode.java
+++ b/catchup-api/src/main/java/com/einschpanner/catchup/global/error/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
 
     // POST
     POST_NOT_FOUND(404, "P001", "게시글을 찾을 수 없습니다."),
+    POST_ACCESS_DENIED(403, "P002", "게시글을 수정, 삭제할 권한이 없습니다."),
 
     // POSTLIKE
     POST_LIKE_DUPLICATED(400, "PL001", "이미 게시글에 좋아요를 한 사용자입니다."),

--- a/catchup-api/src/main/java/com/einschpanner/catchup/post/api/PostCommentController.java
+++ b/catchup-api/src/main/java/com/einschpanner/catchup/post/api/PostCommentController.java
@@ -1,4 +1,4 @@
-package com.einschpanner.catchup.post.controller;
+package com.einschpanner.catchup.post.api;
 
 import com.einschpanner.catchup.post.service.PostCommentService;
 import com.einschpanner.catchup.domain.post.domain.PostComment;

--- a/catchup-api/src/main/java/com/einschpanner/catchup/post/api/PostLikeController.java
+++ b/catchup-api/src/main/java/com/einschpanner/catchup/post/api/PostLikeController.java
@@ -1,4 +1,4 @@
-package com.einschpanner.catchup.post.controller;
+package com.einschpanner.catchup.post.api;
 
 import com.einschpanner.catchup.domain.post.domain.PostLike;
 import com.einschpanner.catchup.domain.user.dto.UserDto;
@@ -19,7 +19,7 @@ public class PostLikeController {
 
     private final PostLikeService postLikeService;
 
-    @PostMapping("/{postId}/like")
+    @PostMapping("/{postId}/likes")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void togglePostLike(
             @PathVariable final Long postId
@@ -29,7 +29,7 @@ public class PostLikeController {
         postLikeService.toggle(postId, userId);
     }
 
-    @GetMapping("/{postId}/like")
+    @GetMapping("/{postId}/likes")
     @ResponseStatus(HttpStatus.OK)
     public List<UserDto.Res> findAllPostLikes(
             @PathVariable final Long postId

--- a/catchup-api/src/main/java/com/einschpanner/catchup/post/exception/PostAccessDeniedException.java
+++ b/catchup-api/src/main/java/com/einschpanner/catchup/post/exception/PostAccessDeniedException.java
@@ -1,0 +1,10 @@
+package com.einschpanner.catchup.post.exception;
+
+import com.einschpanner.catchup.global.error.ErrorCode;
+import com.einschpanner.catchup.global.error.exception.BusinessException;
+
+public class PostAccessDeniedException extends BusinessException {
+    public PostAccessDeniedException() {
+        super(ErrorCode.POST_ACCESS_DENIED);
+    }
+}

--- a/catchup-api/src/main/java/com/einschpanner/catchup/post/service/PostService.java
+++ b/catchup-api/src/main/java/com/einschpanner/catchup/post/service/PostService.java
@@ -1,9 +1,13 @@
 package com.einschpanner.catchup.post.service;
 
+import com.einschpanner.catchup.domain.user.dao.UserRepository;
+import com.einschpanner.catchup.domain.user.domain.User;
+import com.einschpanner.catchup.post.exception.PostAccessDeniedException;
 import com.einschpanner.catchup.post.exception.PostNotFoundException;
 import com.einschpanner.catchup.domain.post.domain.Post;
 import com.einschpanner.catchup.domain.post.dto.PostDto;
 import com.einschpanner.catchup.domain.post.repository.PostRepository;
+import com.einschpanner.catchup.user.exception.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
@@ -16,14 +20,19 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class PostService {
     private final PostRepository postRepository;
+    private final UserRepository userRepository;
     private final ModelMapper modelMapper;
 
     /**
      * 게시글 생성
      */
     @Transactional
-    public Post save(PostDto.CreateReq dto) {
+    public Post save(Long userId, PostDto.CreateReq dto) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+
         Post post = modelMapper.map(dto, Post.class);
+        post.setUser(user);
 
         return postRepository.save(post);
     }
@@ -32,12 +41,8 @@ public class PostService {
      * 게시글 List 모두 조회
      */
     @Transactional
-    public List<PostDto.Res> findAll() {
-        List<Post> postList = postRepository.findAll();
-
-        return postList.stream()
-                .map(PostDto.Res::new)
-                .collect(Collectors.toList());
+    public List<Post> findAll() {
+        return postRepository.findAll();
     }
 
     /**
@@ -53,10 +58,13 @@ public class PostService {
      * 특정 게시글 1개 수정하기
      */
     @Transactional
-    public Post update(Long postId, PostDto.UpdateReq dto) {
+    public Post update(Long userId, Long postId, PostDto.UpdateReq dto) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
         Post post = this.findById(postId);
-        post.updateMyPost(dto);
+        if (post.isNotOwner(user)) throw new PostAccessDeniedException();
 
+        post.updateMyPost(dto);
         return postRepository.save(post);
     }
 
@@ -64,8 +72,13 @@ public class PostService {
      * 특정 게시글 1개 삭제하기
      */
     @Transactional
-    public void delete(Long postId) {
+    public void delete(Long userId, Long postId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+
         Post post = this.findById(postId);
-        post.setDeleted(Boolean.TRUE);
+        if (post.isNotOwner(user)) throw new PostAccessDeniedException();
+
+        post.setIsDeleted(Boolean.TRUE);
     }
 }

--- a/catchup-api/src/test/java/com/einschpanner/catchup/follow/api/FollowControllerTest.java
+++ b/catchup-api/src/test/java/com/einschpanner/catchup/follow/api/FollowControllerTest.java
@@ -1,0 +1,127 @@
+package com.einschpanner.catchup.follow.api;
+
+import com.einschpanner.catchup.domain.follow.domain.Follow;
+import com.einschpanner.catchup.domain.user.domain.User;
+import com.einschpanner.catchup.global.common.ApiDocumentationTest;
+import com.einschpanner.catchup.global.common.WithMockCustomUser;
+import com.einschpanner.catchup.global.common.testFactory.follow.TestFollowFactory;
+import com.einschpanner.catchup.global.common.testFactory.user.TestUserFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class FollowControllerTest extends ApiDocumentationTest {
+
+    private static User user1;
+    private static User user2;
+    private static User user3;
+
+    @BeforeAll
+    public void setUp() {
+        List<User> users = TestUserFactory.getTestUsers();
+        user1 = users.get(0);
+        user2 = users.get(1);
+        user3 = users.get(2);
+    }
+
+    // TODO : 블로그 기능 개발 이후
+    @Test
+    void findMyFollowingBlog() throws Exception {
+    }
+
+    @Test
+    @WithMockCustomUser
+    void toggleFollow() throws Exception {
+        int subscribeId = 1;
+
+        // When & Then
+        mockMvc.perform(post("/following/{subscribeId}", subscribeId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8"))
+                .andDo(print())
+                .andExpect(status().isNoContent())
+                .andDo(document("toggle-follow",
+                        pathParameters(
+                                parameterWithName("subscribeId").description("팔로잉할 USER ID")
+                        )))
+        ;
+    }
+
+    @Test
+    @WithMockUser
+    void findFollowing() throws Exception {
+
+        // Given
+        Follow follow1 = TestFollowFactory.createFollow(1L, user1, user2);
+        Follow follow2 = TestFollowFactory.createFollow(2L, user1, user3);
+
+        List<Follow> follows = new ArrayList<>(
+                Arrays.asList(follow1, follow2)
+        );
+
+        given(followService.findAllFollowing(any(Long.class)))
+                .willReturn(follows);
+
+        int subscribeId = 1;
+        // When & Then
+        mockMvc.perform(get("/following/{subscribeId}", subscribeId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("find-following",
+                        pathParameters(
+                                parameterWithName("subscribeId").description("USER ID")
+                        )))
+        ;
+    }
+
+    @Test
+    @WithMockUser
+    void findFollower() throws Exception {
+
+        // Given
+        Follow follow1 = TestFollowFactory.createFollow(1L, user2, user1);
+        Follow follow2 = TestFollowFactory.createFollow(2L, user3, user1);
+
+        List<Follow> follows = new ArrayList<>(
+                Arrays.asList(follow1, follow2)
+        );
+
+        given(followService.findAllFollower(any(Long.class)))
+                .willReturn(follows);
+
+        int subscribeId = 1;
+        // When & Then
+        mockMvc.perform(get("/follower/{subscribeId}", subscribeId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("find-follower",
+                        pathParameters(
+                                parameterWithName("subscribeId").description("USER ID")
+                        )))
+        ;
+    }
+}

--- a/catchup-api/src/test/java/com/einschpanner/catchup/global/common/ApiDocumentationTest.java
+++ b/catchup-api/src/test/java/com/einschpanner/catchup/global/common/ApiDocumentationTest.java
@@ -1,12 +1,16 @@
 package com.einschpanner.catchup.global.common;
 
 import com.einschpanner.catchup.domain.post.repository.PostQueryRepository;
+import com.einschpanner.catchup.follow.api.FollowController;
+import com.einschpanner.catchup.follow.service.FollowService;
 import com.einschpanner.catchup.global.common.config.TestConfig;
 import com.einschpanner.catchup.global.security.config.SecurityConfig;
 import com.einschpanner.catchup.global.security.controller.AuthController;
-import com.einschpanner.catchup.post.controller.PostCommentController;
-import com.einschpanner.catchup.post.controller.PostController;
+import com.einschpanner.catchup.post.api.PostCommentController;
+import com.einschpanner.catchup.post.api.PostController;
+import com.einschpanner.catchup.post.api.PostLikeController;
 import com.einschpanner.catchup.post.service.PostCommentService;
+import com.einschpanner.catchup.post.service.PostLikeService;
 import com.einschpanner.catchup.post.service.PostService;
 import com.einschpanner.catchup.user.api.UserController;
 import com.einschpanner.catchup.user.service.UserService;
@@ -28,6 +32,8 @@ import org.springframework.test.web.servlet.MockMvc;
 @WebMvcTest(controllers = {
         AuthController.class,
         PostController.class,
+        PostLikeController.class,
+        FollowController.class,
         PostCommentController.class,
         UserController.class
 },
@@ -53,6 +59,12 @@ public abstract class ApiDocumentationTest {
 
     @MockBean
     protected PostQueryRepository postQueryRepository;
+
+    @MockBean
+    protected PostLikeService postLikeService;
+
+    @MockBean
+    protected FollowService followService;
 
     @MockBean
     protected PostCommentService postCommentService;

--- a/catchup-api/src/test/java/com/einschpanner/catchup/global/common/testFactory/follow/TestFollowFactory.java
+++ b/catchup-api/src/test/java/com/einschpanner/catchup/global/common/testFactory/follow/TestFollowFactory.java
@@ -1,0 +1,15 @@
+package com.einschpanner.catchup.global.common.testFactory.follow;
+
+import com.einschpanner.catchup.domain.follow.domain.Follow;
+import com.einschpanner.catchup.domain.user.domain.User;
+
+public class TestFollowFactory {
+
+    public static Follow createFollow(Long followId, User follower, User following ){
+        return Follow.builder()
+                .followId(followId)
+                .follower(follower)
+                .following(following)
+                .build();
+    }
+}

--- a/catchup-api/src/test/java/com/einschpanner/catchup/global/common/testFactory/post/TestPostFactory.java
+++ b/catchup-api/src/test/java/com/einschpanner/catchup/global/common/testFactory/post/TestPostFactory.java
@@ -1,0 +1,70 @@
+package com.einschpanner.catchup.global.common.testFactory.post;
+
+import com.einschpanner.catchup.domain.post.domain.Post;
+import com.einschpanner.catchup.domain.post.dto.PostDto;
+import com.einschpanner.catchup.domain.tag.domain.Tag;
+import com.einschpanner.catchup.domain.user.domain.User;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class TestPostFactory {
+
+    public static Post createPost(Long postId, User user, List<Tag> tags){
+        return Post.builder()
+                .postId(postId)
+                .title("Test Title")
+                .description("Test Description")
+                .email("test@naver.com")
+                .urlThumbnail("Test Thumbnail")
+                .cntLike(0)
+                .cntComment(0)
+                .isDeleted(false)
+                .user(user)
+                .tags(tags)
+                .build();
+    }
+
+    public static PostDto.CreateReq createPostDto() {
+        return PostDto.CreateReq.builder()
+                .title("Test Title")
+                .description("Test Description")
+                .email("test@naver.com")
+                .urlThumbnail("Test Thumbnail")
+                .build();
+    }
+
+    public static PostDto.UpdateReq updatePostDto(){
+        return PostDto.UpdateReq.builder()
+                .title("Update Test Title")
+                .description("Update Test Description")
+                .email("test@naver.com")
+                .urlThumbnail("Update Thumbnail")
+                .cntComment(10)
+                .cntLike(10)
+                .isDeleted(false)
+                .build();
+    }
+
+    public static List<Post> findAllPosts() {
+        return new ArrayList<>(
+                Arrays.asList(
+                        createPost(1L, null, null),
+                        createPost(2L, null, null),
+                        createPost(3L, null, null),
+                        createPost(4L, null, null)
+                ));
+    }
+
+    public static Post findPost(){
+        User user = User.builder()
+                .userId(1L)
+                .nickname("Test User")
+                .email("Test Email")
+                .urlProfile("https://url.link")
+                .build();
+
+        return createPost(1L, user, null);
+    }
+}

--- a/catchup-api/src/test/java/com/einschpanner/catchup/global/common/testFactory/user/TestUserFactory.java
+++ b/catchup-api/src/test/java/com/einschpanner/catchup/global/common/testFactory/user/TestUserFactory.java
@@ -1,0 +1,66 @@
+package com.einschpanner.catchup.global.common.testFactory.user;
+
+import com.einschpanner.catchup.domain.blog.domain.Blog;
+import com.einschpanner.catchup.domain.user.domain.AuthProvider;
+import com.einschpanner.catchup.domain.user.domain.Role;
+import com.einschpanner.catchup.domain.user.domain.User;
+import com.einschpanner.catchup.domain.user.dto.ProfileDto;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class TestUserFactory {
+
+    public static List<User> getTestUsers(){
+        User user1 = User.builder()
+                .userId(1L)
+                .nickname("woowon")
+                .email("wwlee94@naver.com")
+                .urlProfile("https://google.com")
+                .build();
+        User user2 = User.builder()
+                .userId(2L)
+                .nickname("jinyoung")
+                .email("rlawlsdud419@gmail.com")
+                .urlProfile("https://google.com")
+                .build();
+        User user3 = User.builder()
+                .userId(3L)
+                .nickname("TEST")
+                .email("test@gmail.com")
+                .urlProfile("https://kakao.com")
+                .build();
+
+        return new ArrayList<>(
+                Arrays.asList(user1, user2, user3)
+        );
+    }
+
+    public static User createUser(Long userId, List<Blog> blogs){
+        return User.builder()
+                .userId(userId)
+                .nickname("Test Name")
+                .email("Test Email")
+                .urlProfile("https://url.link")
+                .addrBlog("https://blog.link")
+                .addrGithub("https://github.com")
+                .provider(AuthProvider.google)
+                .blogs(blogs)
+                .role(Role.USER)
+                .cntFollower(0)
+                .cntFollowing(0)
+                .build();
+    }
+
+    public static ProfileDto.UpdateReq createProfileDto(){
+        return ProfileDto.UpdateReq.builder()
+                .nickname("testNick")
+                .urlProfile("test Url")
+                .description("description")
+                .addrRss("rss")
+                .addrGithub("github")
+                .addrBlog("blog")
+                .build();
+    }
+}

--- a/catchup-api/src/test/java/com/einschpanner/catchup/post/api/PostControllerTest.java
+++ b/catchup-api/src/test/java/com/einschpanner/catchup/post/api/PostControllerTest.java
@@ -3,16 +3,24 @@ package com.einschpanner.catchup.post.api;
 import com.einschpanner.catchup.domain.post.domain.Post;
 import com.einschpanner.catchup.domain.post.dto.PostDto;
 import com.einschpanner.catchup.global.common.ApiDocumentationTest;
+import com.einschpanner.catchup.global.common.WithMockCustomUser;
+import com.einschpanner.catchup.global.common.testFactory.post.TestPostFactory;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.security.test.context.support.WithMockUser;
+
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -20,17 +28,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class PostControllerTest extends ApiDocumentationTest {
 
     @Test
-    @WithMockUser
+    @WithMockCustomUser
     void savePost() throws Exception {
 
         // Given
-        PostDto.CreateReq postDto = new PostDto.CreateReq();
-        postDto.setDescription("test description");
-        postDto.setEmail("test@naver.com");
-        postDto.setTitle("Test Title");
-        postDto.setUrlThumbnail("Test Thumbnail");
+        PostDto.CreateReq postDto = TestPostFactory.createPostDto();
         Post post = this.modelMapper.map(postDto, Post.class);
-        given(postService.save(any(PostDto.CreateReq.class)))
+
+        given(postService.save(any(Long.class), any(PostDto.CreateReq.class)))
                 .willReturn(post);
 
         // When & Then
@@ -47,6 +52,109 @@ class PostControllerTest extends ApiDocumentationTest {
                                 fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
                                 fieldWithPath("title").type(JsonFieldType.STRING).description("제목"),
                                 fieldWithPath("urlThumbnail").type(JsonFieldType.STRING).description("사진위치")
+                        )
+                ))
+        ;
+    }
+
+    @Test
+    void findAllPosts() throws Exception {
+        // Given
+        List<Post> posts = TestPostFactory.findAllPosts();
+
+        given(postService.findAll())
+                .willReturn(posts);
+
+        // When & Then
+        mockMvc.perform(get("/posts")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("find-all-post"))
+        ;
+    }
+
+    @Test
+    void findPost() throws Exception {
+        // Given
+        Post post = TestPostFactory.findPost();
+
+        given(postService.findById(any(Long.class)))
+                .willReturn(post);
+
+        Long postId = 1L;
+        // When & Then
+        mockMvc.perform(
+                get("/posts/{postId}", postId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("find-post",
+                        pathParameters(
+                                parameterWithName("postId").description("포스트 ID")
+                        )
+                ))
+        ;
+    }
+
+    @Test
+    @WithMockCustomUser
+    void updatePost() throws Exception {
+        // Given
+        PostDto.UpdateReq postDto = TestPostFactory.updatePostDto();
+        System.out.println(postDto);
+
+        Post post = this.modelMapper.map(postDto, Post.class);
+        System.out.println(post);
+
+        System.out.println(objectMapper.writeValueAsString(postDto));
+
+        given(postService.update(any(Long.class), any(Long.class), any(PostDto.UpdateReq.class)))
+                .willReturn(post);
+
+        Long postId = 1L;
+        // When & Then
+        mockMvc.perform(
+                RestDocumentationRequestBuilders.put("/posts/{postId}", postId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(objectMapper.writeValueAsString(postDto))) // ?? 왜 "deleted":false 로 요청이 되는지?
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("update-post",
+                        requestFields(
+                                fieldWithPath("title").type(JsonFieldType.STRING).description("제목"),
+                                fieldWithPath("description").type(JsonFieldType.STRING).description("설명"),
+                                fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
+                                fieldWithPath("urlThumbnail").type(JsonFieldType.STRING).description("사진위치"),
+                                fieldWithPath("cntComment").type(JsonFieldType.NUMBER).description("댓글 개수"),
+                                fieldWithPath("cntLike").type(JsonFieldType.NUMBER).description("좋아요 개수"),
+                                fieldWithPath("isDeleted").type(JsonFieldType.BOOLEAN).description("포스트 삭제 여부")
+                        )
+                ))
+        ;
+    }
+
+    @Test
+    @WithMockCustomUser
+    void deletePost() throws Exception {
+        Long postId = 1L;
+        // When & Then
+        mockMvc.perform(
+                RestDocumentationRequestBuilders.delete("/posts/{postId}", postId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8"))
+                .andDo(print())
+                .andExpect(status().isNoContent())
+                .andDo(document("delete-post",
+                        pathParameters(
+                                parameterWithName("postId").description("포스트 ID")
                         )
                 ))
         ;

--- a/catchup-api/src/test/java/com/einschpanner/catchup/post/api/PostLikeControllerTest.java
+++ b/catchup-api/src/test/java/com/einschpanner/catchup/post/api/PostLikeControllerTest.java
@@ -1,0 +1,93 @@
+package com.einschpanner.catchup.post.api;
+
+import com.einschpanner.catchup.domain.post.domain.Post;
+import com.einschpanner.catchup.domain.post.domain.PostLike;
+import com.einschpanner.catchup.domain.user.domain.User;
+import com.einschpanner.catchup.global.common.ApiDocumentationTest;
+import com.einschpanner.catchup.global.common.WithMockCustomUser;
+import com.einschpanner.catchup.global.common.testFactory.post.TestPostFactory;
+import com.einschpanner.catchup.global.common.testFactory.user.TestUserFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class PostLikeControllerTest extends ApiDocumentationTest {
+
+    private static User user1;
+    private static User user2;
+
+    @BeforeAll
+    public void setUp() {
+        List<User> users = TestUserFactory.getTestUsers();
+        user1 = users.get(0);
+        user2 = users.get(1);
+    }
+
+    @Test
+    @WithMockCustomUser
+    void togglePostLike() throws Exception {
+        Long postId = 1L;
+
+        // When & Then
+        mockMvc.perform(post("/posts/{postId}/likes", postId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8"))
+                .andDo(print())
+                .andExpect(status().isNoContent())
+                .andDo(document("toggle-follow",
+                        pathParameters(
+                                parameterWithName("postId").description("포스트 ID")
+                        )
+                ))
+        ;
+    }
+
+    @Test
+    @WithMockUser
+    void findAllPostLikes()throws Exception {
+
+        Post post = TestPostFactory.createPost(1L, user1, null);
+
+        // Given
+        List<PostLike> postLikes = new ArrayList<>();
+        PostLike postLike1 = PostLike.of(post, user1);
+        postLikes.add(postLike1);
+        PostLike postLike2 = PostLike.of(post, user2);
+        postLikes.add(postLike2);
+
+        given(postLikeService.findAllByPostId(any(Long.class)))
+                .willReturn(postLikes);
+
+        Long postId = 1L;
+        // When & Then
+        mockMvc.perform(get("/posts/{postId}/likes", postId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("find-post-likes",
+                        pathParameters(
+                                parameterWithName("postId").description("포스트 ID")
+                        ))
+                )
+        ;
+    }
+}

--- a/catchup-api/src/test/java/com/einschpanner/catchup/user/api/UserControllerTest.java
+++ b/catchup-api/src/test/java/com/einschpanner/catchup/user/api/UserControllerTest.java
@@ -3,6 +3,7 @@ package com.einschpanner.catchup.user.api;
 import com.einschpanner.catchup.domain.user.dto.ProfileDto;
 import com.einschpanner.catchup.global.common.ApiDocumentationTest;
 import com.einschpanner.catchup.global.common.WithMockCustomUser;
+import com.einschpanner.catchup.global.common.testFactory.user.TestUserFactory;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
@@ -23,14 +24,7 @@ class UserControllerTest extends ApiDocumentationTest {
     @WithMockCustomUser
     void saveProfile() throws Exception {
         // Given
-        ProfileDto.UpdateReq req = ProfileDto.UpdateReq.builder()
-                .nickname("testNick")
-                .urlProfile("test Url")
-                .description("description")
-                .addrRss("rss")
-                .addrGithub("github")
-                .addrBlog("blog")
-                .build();
+        ProfileDto.UpdateReq req = TestUserFactory.createProfileDto();
 
         // When & Then
         mockMvc.perform(post("/profiles")

--- a/catchup-domain/src/main/java/com/einschpanner/catchup/domain/follow/dao/FollowQueryRepository.java
+++ b/catchup-domain/src/main/java/com/einschpanner/catchup/domain/follow/dao/FollowQueryRepository.java
@@ -1,0 +1,42 @@
+package com.einschpanner.catchup.domain.follow.dao;
+
+import com.einschpanner.catchup.domain.follow.domain.Follow;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.einschpanner.catchup.domain.follow.domain.QFollow.follow;
+
+@RequiredArgsConstructor
+@Repository
+public class FollowQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public Follow exists(Long followerId, Long followingId) {
+
+        return queryFactory
+                .selectFrom(follow)
+                .where(follow.follower.userId.eq(followerId))
+                .where(follow.following.userId.eq(followingId))
+                .fetchOne();
+    }
+
+    public List<Follow> findAllFollowingByFollowerId(Long followerId){
+
+        return queryFactory
+                .selectFrom(follow)
+                .where(follow.follower.userId.eq(followerId))
+                .fetch();
+    }
+
+    public List<Follow> findAllFollowerByFollowingId(Long followingId){
+
+        return queryFactory
+                .selectFrom(follow)
+                .where(follow.following.userId.eq(followingId))
+                .fetch();
+    }
+}

--- a/catchup-domain/src/main/java/com/einschpanner/catchup/domain/follow/dao/FollowRepository.java
+++ b/catchup-domain/src/main/java/com/einschpanner/catchup/domain/follow/dao/FollowRepository.java
@@ -1,4 +1,9 @@
 package com.einschpanner.catchup.domain.follow.dao;
 
-public class FollowRepository {
+import com.einschpanner.catchup.domain.follow.domain.Follow;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FollowRepository extends JpaRepository<Follow, Long> {
 }

--- a/catchup-domain/src/main/java/com/einschpanner/catchup/domain/follow/domain/Follow.java
+++ b/catchup-domain/src/main/java/com/einschpanner/catchup/domain/follow/domain/Follow.java
@@ -1,10 +1,7 @@
 package com.einschpanner.catchup.domain.follow.domain;
 
 import com.einschpanner.catchup.domain.user.domain.User;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.*;
 
@@ -14,6 +11,7 @@ import javax.persistence.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@ToString
 public class Follow {
 
     @Id
@@ -27,6 +25,13 @@ public class Follow {
     @ManyToOne
     @JoinColumn(name = "followerId")
     private User follower;
+
+    public static Follow of(User follower, User following){
+        return Follow.builder()
+                .follower(follower)
+                .following(following)
+                .build();
+    }
 }
 
 

--- a/catchup-domain/src/main/java/com/einschpanner/catchup/domain/follow/dto/FollowDto.java
+++ b/catchup-domain/src/main/java/com/einschpanner/catchup/domain/follow/dto/FollowDto.java
@@ -1,0 +1,51 @@
+package com.einschpanner.catchup.domain.follow.dto;
+
+import com.einschpanner.catchup.domain.blog.domain.Blog;
+import com.einschpanner.catchup.domain.follow.domain.Follow;
+import com.einschpanner.catchup.domain.user.domain.User;
+import com.einschpanner.catchup.domain.user.dto.UserDto;
+import lombok.Getter;
+
+import java.util.List;
+
+public class FollowDto {
+
+    @Getter
+    public static class FollowingRes {
+
+        private Long followId;
+        private UserDto.Res user;
+
+        public FollowingRes(Follow follow){
+            this.followId = follow.getFollowId();
+            this.user = new UserDto.Res(follow.getFollowing());
+        }
+    }
+
+    @Getter
+    public static class FollowerRes {
+
+        private Long followId;
+        private UserDto.Res user;
+
+        public FollowerRes(Follow follow){
+            this.followId = follow.getFollowId();
+            this.user = new UserDto.Res(follow.getFollower());
+        }
+    }
+
+    @Getter
+    public static class BlogRes {
+
+        private Long followId;
+        private UserDto.Res user;
+        private List<Blog> blogs;
+
+        public BlogRes(Follow follow){
+            User user = follow.getFollowing();
+            this.followId = follow.getFollowId();
+            this.user = new UserDto.Res(user);
+            this.blogs = user.getBlogs();
+        }
+    }
+}

--- a/catchup-domain/src/main/java/com/einschpanner/catchup/domain/post/domain/Post.java
+++ b/catchup-domain/src/main/java/com/einschpanner/catchup/domain/post/domain/Post.java
@@ -41,10 +41,11 @@ public class Post extends BaseTimeEntity {
 
     @Column
     @Setter
-    private boolean isDeleted;
+    private Boolean isDeleted;
 
     @ManyToOne
     @JoinColumn(name = "userId")
+    @Setter
     private User user;
 
     @OneToMany
@@ -62,7 +63,7 @@ public class Post extends BaseTimeEntity {
         this.urlThumbnail = dto.getUrlThumbnail();
         this.cntLike = dto.getCntLike();
         this.cntComment = dto.getCntComment();
-        this.isDeleted = dto.isDeleted();
+        this.isDeleted = dto.getIsDeleted();
     }
 
     public void plusCommentCnt() {
@@ -72,6 +73,7 @@ public class Post extends BaseTimeEntity {
     public void minusCommentCnt() {
         this.cntComment--;
     }
+
     public void plusLikeCnt() {
         this.cntLike++;
     }
@@ -80,5 +82,8 @@ public class Post extends BaseTimeEntity {
         this.cntLike--;
     }
 
+    public boolean isNotOwner(User user){
+        return !this.user.getUserId().equals(user.getUserId());
+    }
 }
 

--- a/catchup-domain/src/main/java/com/einschpanner/catchup/domain/post/dto/PostDto.java
+++ b/catchup-domain/src/main/java/com/einschpanner/catchup/domain/post/dto/PostDto.java
@@ -1,6 +1,7 @@
 package com.einschpanner.catchup.domain.post.dto;
 
 import com.einschpanner.catchup.domain.post.domain.Post;
+import com.einschpanner.catchup.domain.user.dto.UserDto;
 import lombok.*;
 
 public class PostDto {
@@ -21,6 +22,9 @@ public class PostDto {
     @Getter
     @Setter
     @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @ToString
     public static class UpdateReq {
 
         private String title;
@@ -29,7 +33,7 @@ public class PostDto {
         private String urlThumbnail;
         private int cntComment;
         private int cntLike;
-        private boolean isDeleted;
+        private Boolean isDeleted;
     }
 
     @Getter
@@ -51,6 +55,30 @@ public class PostDto {
             this.urlThumbnail = post.getUrlThumbnail();
             this.cntLike = post.getCntLike();
             this.cntComment = post.getCntComment();
+        }
+    }
+
+    @Getter
+    public static class ResWithUser {
+
+        private Long id;
+        private String title;
+        private String description;
+        private String email;
+        private String urlThumbnail;
+        private int cntLike;
+        private int cntComment;
+        private UserDto.Res user;
+
+        public ResWithUser(Post post) {
+            this.id = post.getPostId();
+            this.title = post.getTitle();
+            this.description = post.getDescription();
+            this.email = post.getEmail();
+            this.urlThumbnail = post.getUrlThumbnail();
+            this.cntLike = post.getCntLike();
+            this.cntComment = post.getCntComment();
+            this.user = new UserDto.Res(post.getUser());
         }
     }
 }

--- a/catchup-domain/src/main/java/com/einschpanner/catchup/domain/user/domain/User.java
+++ b/catchup-domain/src/main/java/com/einschpanner/catchup/domain/user/domain/User.java
@@ -84,4 +84,20 @@ public class User extends BaseTimeEntity {
 
         return this;
     }
+
+    public void plusFollowerCount(){
+        this.cntFollower++;
+    }
+
+    public void minusFollowerCount(){
+        this.cntFollower--;
+    }
+
+    public void plusFollowingCount(){
+        this.cntFollowing++;
+    }
+
+    public void minusFollowingCount(){
+        this.cntFollowing--;
+    }
 }

--- a/catchup-security/src/main/java/com/einschpanner/catchup/global/security/config/SecurityConfig.java
+++ b/catchup-security/src/main/java/com/einschpanner/catchup/global/security/config/SecurityConfig.java
@@ -1,9 +1,9 @@
 package com.einschpanner.catchup.global.security.config;
 
-import com.einschpanner.catchup.global.security.provider.JwtTokenProvider;
-import com.einschpanner.catchup.global.security.service.CustomOAuth2UserService;
 import com.einschpanner.catchup.global.security.filter.JwtAuthenticationFilter;
 import com.einschpanner.catchup.global.security.handler.OAuth2AuthenticationSuccessHandler;
+import com.einschpanner.catchup.global.security.provider.JwtTokenProvider;
+import com.einschpanner.catchup.global.security.service.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -27,7 +27,14 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
                     .authorizeRequests()
-                    .antMatchers("/","/css/**","/images/**","/js/**","/h2-console/**", "/hello", "/login").permitAll()
+                    .antMatchers(
+                            "/",
+                            "/css/**",
+                            "/images/**",
+                            "/js/**",
+                            "/h2-console/**",
+                            "/login"
+                    ).permitAll()
                     .antMatchers(HttpMethod.GET).permitAll()
                 .anyRequest().authenticated()
                 .and()


### PR DESCRIPTION
## 팔로우 API 기능 

- 팔로우하기 API - `POST /follow`
- 팔로우 취소 API - `POST /follow`
- 특정 ID가 팔로잉하는 사용자 리스트 불러오기 - `GET /following/{userId}`
- 특정 ID의 팔로워 리스트 불러오기 - `GET /follower/{userId}`
- PostLike 테스트 코드, Follow 테스트 코드 작성
- Post Contoller 리팩토링 (userId 연결)